### PR TITLE
Add missing `IsBitSet` function and fix imports

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,5 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=

--- a/rcb.go
+++ b/rcb.go
@@ -3,6 +3,7 @@ package iec61850
 // #include <iec61850_client.h>
 // #include <iec61850_common.h>
 import "C"
+
 import (
 	"unsafe"
 )
@@ -45,7 +46,7 @@ func (c *Client) ReadRbcValues(objectReference string) (*ClientReportControlBloc
 		Ena:     c.getRbcEnable(rcb),
 		IntgPd:  int(c.getRbcIntgPd(rcb)),
 		TrgOps:  c.getTrgOps(rcb),
-		OptFlds: c.getOptFinds(rcb),
+		OptFlds: c.getOptFlds(rcb),
 	}, nil
 }
 
@@ -59,9 +60,9 @@ func (c *Client) getRbcIntgPd(rcb C.ClientReportControlBlock) uint32 {
 	return uint32(intgPd)
 }
 
-func (c *Client) getOptFinds(rcb C.ClientReportControlBlock) OptFlds {
-	optFinds := C.ClientReportControlBlock_getOptFlds(rcb)
-	g := int(optFinds)
+func (c *Client) getOptFlds(rcb C.ClientReportControlBlock) OptFlds {
+	optFlds := C.ClientReportControlBlock_getOptFlds(rcb)
+	g := int(optFlds)
 	return OptFlds{
 		SequenceNumber:     IsBitSet(g, 0),
 		TimeOfEntry:        IsBitSet(g, 1),
@@ -139,7 +140,7 @@ func (c *Client) SetRbcValues(objectReference string, settings ClientReportContr
 		optFlds = optFlds | C.RPT_OPT_CONF_REV
 	}
 
-	C.ClientReportControlBlock_setTrgOps(rcb, trgOps)                      //触发条件
+	C.ClientReportControlBlock_setTrgOps(rcb, trgOps)                      // 触发条件
 	C.ClientReportControlBlock_setRptEna(rcb, C.bool(settings.Ena))        // 报告使能
 	C.ClientReportControlBlock_setIntgPd(rcb, C.uint32_t(settings.IntgPd)) // 周期上送时间
 	C.ClientReportControlBlock_setOptFlds(rcb, optFlds)
@@ -148,4 +149,8 @@ func (c *Client) SetRbcValues(objectReference string, settings ClientReportContr
 		return err
 	}
 	return nil
+}
+
+func IsBitSet(val int, pos int) bool {
+	return (val & (1 << pos)) != 0
 }

--- a/test/client_rbc_test.go
+++ b/test/client_rbc_test.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"fmt"
-	"github.com/buhuang28/iec61850"
 	"testing"
+
+	"github.com/wendy512/iec61850"
 )
 
 func TestRBC(t *testing.T) {


### PR DESCRIPTION
Adds a missing function that was causing build errors, and updates the imports to use the base repo rather than a fork.

Also renames one of the functions to be closer to the name of the type it's returning.