### PR TITLE
Add `NewIedModelFromPointer()`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/validator.v2 v2.0.1 // indirect
 )
+
+replace github.com/wendy512/iec61850 => ./

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/morris-kelly/wendy512iec61850
+module github.com/wendy512/iec61850
 
 go 1.19
 
@@ -13,3 +13,5 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
+
+replace github.com/wendy512/iec61850 => ./

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,12 @@ go 1.19
 
 require (
 	github.com/spf13/cast v1.6.0
+	github.com/spf13/cobra v1.8.1
 	golang.org/x/text v0.16.0
+	gopkg.in/validator.v2 v2.0.1
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	gopkg.in/validator.v2 v2.0.1 // indirect
 )
-
-replace github.com/wendy512/iec61850 => ./

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wendy512/iec61850
+module github.com/morris-kelly/wendy512iec61850
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,3 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
-
-replace github.com/wendy512/iec61850 => ./

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
 gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.work
+++ b/go.work
@@ -1,1 +1,0 @@
-replace github.com/wendy512/iec61850 => ./

--- a/go.work
+++ b/go.work
@@ -1,0 +1,1 @@
+replace github.com/wendy512/iec61850 => ./

--- a/model.go
+++ b/model.go
@@ -2,6 +2,7 @@ package iec61850
 
 // #include <iec61850_server.h>
 import "C"
+
 import (
 	"os"
 	"unsafe"
@@ -9,6 +10,15 @@ import (
 
 type IedModel struct {
 	_iedModel *C.IedModel
+}
+
+// This is a little hacky but it works for calls from runtime_scl.
+//
+// The pointer must be a pointer to the C version of the IedModel.
+func NewIedModelFromPointer(model unsafe.Pointer) *IedModel {
+	return &IedModel{
+		_iedModel: (*C.IedModel)(model),
+	}
 }
 
 type ModelNode struct {

--- a/model.go
+++ b/model.go
@@ -9,7 +9,7 @@ import (
 )
 
 type IedModel struct {
-	_iedModel *C.IedModel
+	Model *C.IedModel
 }
 
 // This is a little hacky but it works for calls from runtime_scl.
@@ -17,7 +17,7 @@ type IedModel struct {
 // The pointer must be a pointer to the C version of the IedModel.
 func NewIedModelFromPointer(model unsafe.Pointer) *IedModel {
 	return &IedModel{
-		_iedModel: (*C.IedModel)(model),
+		Model: (*C.IedModel)(model),
 	}
 }
 
@@ -30,19 +30,19 @@ func NewIedModel(name string) *IedModel {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 	return &IedModel{
-		_iedModel: C.IedModel_create(cname),
+		Model: C.IedModel_create(cname),
 	}
 }
 
 func (m *IedModel) Destroy() {
-	C.IedModel_destroy(m._iedModel)
+	C.IedModel_destroy(m.Model)
 }
 
 func (m *IedModel) GetModelNodeByObjectReference(objectRef string) *ModelNode {
 	cObjectRef := C.CString(objectRef)
 	defer C.free(unsafe.Pointer(cObjectRef))
 
-	do := C.IedModel_getModelNodeByObjectReference(m._iedModel, cObjectRef)
+	do := C.IedModel_getModelNodeByObjectReference(m.Model, cObjectRef)
 	if do == nil {
 		return nil
 	}
@@ -59,7 +59,7 @@ func CreateModelFromConfigFileEx(filepath string) (*IedModel, error) {
 	// 释放内存
 	defer C.free(unsafe.Pointer(cFilepath))
 	model := &IedModel{
-		_iedModel: C.ConfigFileParser_createModelFromConfigFileEx(cFilepath),
+		Model: C.ConfigFileParser_createModelFromConfigFileEx(cFilepath),
 	}
 	return model, nil
 }
@@ -72,7 +72,7 @@ func (m *IedModel) CreateLogicalDevice(name string) *LogicalDevice {
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 	return &LogicalDevice{
-		device: C.LogicalDevice_create(cname, m._iedModel),
+		device: C.LogicalDevice_create(cname, m.Model),
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package iec61850
 
 // #include <iec61850_server.h>
 import "C"
+
 import (
 	"unsafe"
 )
@@ -22,7 +23,7 @@ func NewServerWithTlsSupport(serverConfig ServerConfig, tlsConfig *TLSConfig, ie
 	config := serverConfig.createIedServerConfig(serverConfig)
 	defer C.IedServerConfig_destroy(config)
 	return &IedServer{
-		server:       C.IedServer_createWithConfig(iedModel._iedModel, cTlsConfig, config),
+		server:       C.IedServer_createWithConfig(iedModel.Model, cTlsConfig, config),
 		serverConfig: serverConfig,
 		tlsConfig:    cTlsConfig,
 	}, nil
@@ -32,7 +33,7 @@ func NewServerWithConfig(serverConfig ServerConfig, iedModel *IedModel) *IedServ
 	config := serverConfig.createIedServerConfig(serverConfig)
 	defer C.IedServerConfig_destroy(config)
 	return &IedServer{
-		server:       C.IedServer_createWithConfig(iedModel._iedModel, nil, config),
+		server:       C.IedServer_createWithConfig(iedModel.Model, nil, config),
 		serverConfig: serverConfig,
 	}
 }
@@ -40,7 +41,7 @@ func NewServerWithConfig(serverConfig ServerConfig, iedModel *IedModel) *IedServ
 // NewServer creates a new instance of the IedServer using the provided _iedModel.
 func NewServer(iedModel *IedModel) *IedServer {
 	return &IedServer{
-		server: C.IedServer_create(iedModel._iedModel),
+		server: C.IedServer_create(iedModel.Model),
 	}
 }
 

--- a/server_handler.go
+++ b/server_handler.go
@@ -28,6 +28,7 @@ static Buffer AcseAuthenticationParameter_GetBuffer(AcseAuthenticationParameter 
 }
 */
 import "C"
+
 import (
 	"fmt"
 	"sync/atomic"


### PR DESCRIPTION
This PR adds one function to enable cross-library server generation if a compatible model is generated. This gets around the issues of generated C types not working across modules.

I've also tidied the `go.mod` file.