### PR TITLE
Remove -v flag from all configs

### DIFF
--- a/config_armv7l.go
+++ b/config_armv7l.go
@@ -3,5 +3,5 @@
 package iec61850
 
 // #cgo CFLAGS: -I./libiec61850/inc/hal/inc -I./libiec61850/inc/common/inc -I./libiec61850/inc/goose -I./libiec61850/inc/iec61850/inc -I./libiec61850/inc/iec61850/inc_private -I./libiec61850/inc/logging -I./libiec61850/inc/mms/inc -I./libiec61850/inc/mms/inc_private -I./libiec61850/inc/mms/iso_mms/asn1c
-// #cgo LDFLAGS: -static-libgcc -v -static-libstdc++ -L./libiec61850/lib/linux_armv7l -liec61850 -lpthread
+// #cgo LDFLAGS: -static-libgcc -static-libstdc++ -L./libiec61850/lib/linux_armv7l -liec61850 -lpthread
 import "C"

--- a/config_armv8.go
+++ b/config_armv8.go
@@ -3,5 +3,5 @@
 package iec61850
 
 // #cgo CFLAGS: -I./libiec61850/inc/hal/inc -I./libiec61850/inc/common/inc -I./libiec61850/inc/goose -I./libiec61850/inc/iec61850/inc -I./libiec61850/inc/iec61850/inc_private -I./libiec61850/inc/logging -I./libiec61850/inc/mms/inc -I./libiec61850/inc/mms/inc_private -I./libiec61850/inc/mms/iso_mms/asn1c
-// #cgo LDFLAGS: -static-libgcc -v -static-libstdc++ -L./libiec61850/lib/linux_armv8 -liec61850 -lpthread
+// #cgo LDFLAGS: -static-libgcc -static-libstdc++ -L./libiec61850/lib/linux_armv8 -liec61850 -lpthread
 import "C"

--- a/config_darwinarmv8.go
+++ b/config_darwinarmv8.go
@@ -3,5 +3,5 @@
 package iec61850
 
 // #cgo CFLAGS: -I./libiec61850/inc/hal/inc -I./libiec61850/inc/common/inc -I./libiec61850/inc/goose -I./libiec61850/inc/iec61850/inc -I./libiec61850/inc/iec61850/inc_private -I./libiec61850/inc/logging -I./libiec61850/inc/mms/inc -I./libiec61850/inc/mms/inc_private -I./libiec61850/inc/mms/iso_mms/asn1c
-// #cgo LDFLAGS: -static-libstdc++ -v -L./libiec61850/lib/darwin_armv8 -liec61850 -lpthread
+// #cgo LDFLAGS: -static-libstdc++ -L./libiec61850/lib/darwin_armv8 -liec61850 -lpthread
 import "C"

--- a/config_linux64.go
+++ b/config_linux64.go
@@ -3,5 +3,5 @@
 package iec61850
 
 // #cgo CFLAGS: -I./libiec61850/inc/hal/inc -I./libiec61850/inc/common/inc -I./libiec61850/inc/goose -I./libiec61850/inc/iec61850/inc -I./libiec61850/inc/iec61850/inc_private -I./libiec61850/inc/logging -I./libiec61850/inc/mms/inc -I./libiec61850/inc/mms/inc_private -I./libiec61850/inc/mms/iso_mms/asn1c
-// #cgo LDFLAGS: -static-libgcc -v -static-libstdc++ -L./libiec61850/lib/linux64 -liec61850 -lpthread
+// #cgo LDFLAGS: -static-libgcc -static-libstdc++ -L./libiec61850/lib/linux64 -liec61850 -lpthread
 import "C"

--- a/config_win64.go
+++ b/config_win64.go
@@ -3,5 +3,5 @@
 package iec61850
 
 // #cgo CFLAGS: -I./libiec61850/inc/hal/inc -I./libiec61850/inc/common/inc -I./libiec61850/inc/goose -I./libiec61850/inc/iec61850/inc -I./libiec61850/inc/iec61850/inc_private -I./libiec61850/inc/logging -I./libiec61850/inc/mms/inc -I./libiec61850/inc/mms/inc_private -I./libiec61850/inc/mms/iso_mms/asn1c
-// #cgo LDFLAGS: -static-libgcc -v -static-libstdc++ -L./libiec61850/lib/win64 -liec61850 -lws2_32
+// #cgo LDFLAGS: -static-libgcc -static-libstdc++ -L./libiec61850/lib/win64 -liec61850 -lws2_32
 import "C"


### PR DESCRIPTION
The `-v` flag is fine for debugging, but it outputting massive amounts of stuff to the terminal during tests and builds. I propose that it's removed. 

I note that there are issues with the go-vet, which has been fixed in #17 